### PR TITLE
dot path or object in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ queue_config = {
     "my-kafka-input": {
       "value": "my.kafka.topic.name",
       "profile": "confluent",
-      "data_model": "my_config.InputMessage",
+      "data_model": InputMessage,
       "config": {
         "bootstrap.servers": "localhost:9092",
         "group.id": "my.consumer.group"
@@ -88,6 +88,7 @@ queue_config = {
     "my-redis-output": {
       "value": "my.redis.output.queue.name",
       "profile": "rsmq",
+      "data_model": OutputMessage,
       "config": {
         "host": "localhost",
         "port": 6379,

--- a/example/intro/my_config.py
+++ b/example/intro/my_config.py
@@ -19,13 +19,13 @@ queue_config = {
     "my-kafka-input": {
         "value": "my.kafka.topic.name",
         "profile": "confluent",
-        "data_model": "my_config.InputMessage",
+        "data_model": InputMessage,
         "config": {"bootstrap.servers": os.getenv("KAFKA_BROKERS", "localhost:9092"), "group.id": "my.consumer.group"},
     },
     "my-redis-output": {
         "value": "my.redis.output.queue.name",
-        "data_model": "my_config.OutputMessage",
         "profile": "rsmq",
+        "data_model": OutputMessage,
         "config": {
             "host": os.getenv("REDIS_HOST", "localhost"),
             "port": 6379,

--- a/example/kafka_kafka_worker.py
+++ b/example/kafka_kafka_worker.py
@@ -14,13 +14,13 @@ queue_config = {
     "input-topic": {
         "value": INPUT_TOPIC,
         "profile": "confluent",
-        "data_model": "example.data_models.InputMessage",
+        "data_model": InputMessage,
         "config": {"group.id": CONSUMER_GROUP},
     },
     "output-topic": {
         "value": OUTPUT_TOPIC,
         "profile": "confluent",
-        "data_model": "example.data_models.KafkaKafkaOutput",
+        "data_model": KafkaKafkaOutput,
     },
     "dead-letter-queue": {
         "value": "localhost.kafka.kafka.dlq",

--- a/example/middle_worker.py
+++ b/example/middle_worker.py
@@ -12,10 +12,9 @@ from example.data_models import (
 )
 from example.plugins.my_plugin import MyPGConsumer
 from volley.data_models import GenericMessage
-from volley.models.pydantic_model import PydanticModelHandler
 from volley.engine import Engine
 from volley.logging import logger
-from volley.models import PydanticModelHandler
+from volley.models.pydantic_model import PydanticModelHandler
 from volley.serializers import MsgPackSerialization
 
 logging.basicConfig(level=logging.INFO)

--- a/example/middle_worker.py
+++ b/example/middle_worker.py
@@ -12,6 +12,7 @@ from example.data_models import (
 )
 from example.plugins.my_plugin import MyPGConsumer
 from volley.data_models import GenericMessage
+from volley.models.pydantic_model import PydanticModelHandler
 from volley.engine import Engine
 from volley.logging import logger
 from volley.models import PydanticModelHandler
@@ -27,6 +28,7 @@ queue_config = {
         "profile": "rsmq",
         "serializer": MsgPackSerialization,
         "data_model": GenericMessage,
+        "model_handler": PydanticModelHandler,
     },
     "postgres_queue": {
         "value": "my_long_table_name",

--- a/example/middle_worker.py
+++ b/example/middle_worker.py
@@ -10,11 +10,14 @@ from example.data_models import (
     PostgresMessage,
     Queue1Message,
 )
+from example.plugins.my_plugin import MyPGConsumer
+from volley.data_models import GenericMessage
 from volley.engine import Engine
 from volley.logging import logger
+from volley.models import PydanticModelHandler
+from volley.serializers import MsgPackSerialization
 
 logging.basicConfig(level=logging.INFO)
-
 
 queue_config = {
     # define queue configurations in a dict
@@ -22,27 +25,28 @@ queue_config = {
     "redis_queue": {
         "value": "long_name_1",
         "profile": "rsmq",
-        "serializer": "volley.serializers.MsgPackSerialization",
-        "data_model": "volley.data_models.GenericMessage",
+        "serializer": MsgPackSerialization,
+        "data_model": GenericMessage,
     },
     "postgres_queue": {
         "value": "my_long_table_name",
         "data_model": "example.data_models.PostgresMessage",
-        "model_handler": "volley.models.PydanticModelHandler",
+        "model_handler": PydanticModelHandler,
         # disable serializer - sqlachemy implementation in example/plugin/my_plugin.py handles this
         "serializer": "disabled",
+        # both dot path to the object or the object itself are valid
         "producer": "example.plugins.my_plugin.MyPGProducer",
-        "consumer": "example.plugins.my_plugin.MyPGConsumer",
+        "consumer": MyPGConsumer,
     },
     "input-topic": {
         "value": "localhost.kafka.input",
         "profile": "confluent",
-        "data_model": "example.data_models.InputMessage",
+        "data_model": InputMessage,
     },
     "output-topic": {
         "value": "localhost.kafka.output",
         "profile": "confluent-pydantic",
-        "data_model": "example.data_models.OutputMessage",
+        "data_model": OutputMessage,
     },
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from volley.connectors import (
     RSMQConsumer,
     RSMQProducer,
 )
-from volley.data_models import QueueMessage
+from volley.data_models import GenericMessage, QueueMessage
 from volley.engine import Engine
 from volley.profiles import ConnectionType, Profile
 
@@ -170,7 +170,7 @@ def config_dict() -> Dict[str, Dict[str, Any]]:
         "comp_1": {
             "value": "comp1",
             "profile": "rsmq",
-            "data_model": "volley.data_models.GenericMessage",
+            "data_model": GenericMessage,
         },
         "output-topic": {
             "value": "localhost.kafka.output",

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -123,7 +123,7 @@ def test_invalid_handler_config(confluent_consumer_profile: Profile) -> None:
     ],
 )
 def test_profile_override(data_model: Optional[str], model_handler: Optional[str], serializer: Optional[str]) -> None:
-    """all or none of a profiles can be overriden by the user"""
+    """all or none of a profiles can be overridden by the user"""
     qname = "test-topic"
     consumer_group = str(uuid4())
     qvalue = "test.topic"

--- a/volley/profiles.py
+++ b/volley/profiles.py
@@ -26,7 +26,6 @@ class Profile(BaseModel):
 
     connection_type: ConnectionType
     # dot path to the object, or the object itself
-    # https://mypy.readthedocs.io/en/latest/kinds_of_types.html#the-type-of-class-objects
     consumer: Optional[Union[str, Type[BaseConsumer]]]
     producer: Optional[Union[str, Type[BaseProducer]]]
     model_handler: Optional[Union[str, Type[BaseModelHandler]]]

--- a/volley/queues.py
+++ b/volley/queues.py
@@ -43,26 +43,38 @@ class Queue:
     def __post_init__(self) -> None:
         """Load modules provided in Profile"""
         # data model is assigned by not instantiated
-        if self.profile.data_model is not None:
+        if isinstance(self.profile.data_model, str):
             self.data_model = import_module_from_string(self.profile.data_model)
+        elif self.profile.data_model is not None:
+            self.data_model = self.profile.data_model
 
         # model_handler and serializer are instantiated on init
-        if self.profile.model_handler is not None:
+        if isinstance(self.profile.model_handler, str):
             self.model_handler = import_module_from_string(self.profile.model_handler)()
-        if self.profile.serializer is not None:
+        elif self.profile.model_handler is not None:
+            self.model_handler = self.profile.model_handler()
+        if isinstance(self.profile.serializer, str):
             self.serializer = import_module_from_string(self.profile.serializer)()
+        elif self.profile.serializer is not None:
+            self.serializer = self.profile.serializer()
 
     def connect(self, con_type: ConnectionType) -> None:
         """instantiate the connector class"""
         if con_type == ConnectionType.CONSUMER:
             if self.profile.consumer is None:
                 raise ValueError("Must provide a consumer connector")
-            _class = import_module_from_string(self.profile.consumer)
+            if isinstance(self.profile.consumer, str):
+                _class = import_module_from_string(self.profile.consumer)
+            else:
+                _class = self.profile.consumer
             self.consumer_con = _class(queue_name=self.value, config=self.pass_through_config.copy())
         elif con_type == ConnectionType.PRODUCER:
             if self.profile.producer is None:
                 raise ValueError("Must provide a producer connector")
-            _class = import_module_from_string(self.profile.producer)
+            if isinstance(self.profile.producer, str):
+                _class = import_module_from_string(self.profile.producer)
+            else:
+                _class = self.profile.producer
             self.producer_con = _class(queue_name=self.value, config=self.pass_through_config.copy())
         else:
             raise TypeError(f"{con_type=} is not valid")


### PR DESCRIPTION
Previously volley only support dot paths for any of the data model, serializer, connector, and model handlers. For example, to define the pydantic model for data in a queue, we'd pass in the full dot path string to the location of that model.

```python
config = {
  ...,
  "data_model": "path.to.my_module.DefinedModel"
}
```

Now we can pass the object in to configuration directly:
```python
from path.to.my_module import DefinedModel
config = {
  ...,
  "data_model": DefinedModel
}
```

This applies to all the configuration items that were "dot path referenced".
https://github.com/shipt/py-volley/blob/373b75b2eed6362f07abcbcc4eb00172862b175e/example/middle_worker.py#L26-L32