### PR TITLE
ZeroMQ support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test.unit: setup
             --cov-report term
 
 run.components:
-	docker-compose up --build -d input_worker middle_worker 
+	docker-compose up --build -d input_worker middle_worker zmq_worker
 
 run.example: run.datastores run.components run.externals
 	docker compose up --build -d data_producer input_worker middle_worker data_consumer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,136 +1,147 @@
-version: '3.5'
+version: "3.5"
 services:
-    data_producer:
-        environment:
-            - REDIS_HOST=redis
-            - REDIS_PORT=6379
-            - KAFKA_BROKERS=kafka:9092
-        build:
-            context: .
-            dockerfile: Dockerfile
-            target: dev
-        depends_on:
-            - kafka
-        volumes:
-            - ./:/app/ 
-        # ports:
-        #     - 5678:5678
-        # command: python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m example.external_data_producer
-        command: python -m example.external_data_producer
+  data_producer:
+    environment:
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - KAFKA_BROKERS=kafka:9092
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: dev
+    depends_on:
+      - kafka
+    volumes:
+      - ./:/app/
+    # ports:
+    #     - 5678:5678
+    # command: python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m example.external_data_producer
+    command: python -m example.external_data_producer
 
-    input_worker:
-        environment:
-            - REDIS_HOST=redis
-            - REDIS_PORT=6379
-            - KAFKA_BROKERS=kafka:9092
-        build:
-            target: dev
-            context: .
-            dockerfile: Dockerfile
-        depends_on:
-            - kafka
-            - redis
-        volumes:
-            - ./:/app/
-        # ports:
-        #     - 3000:3000
-        #     - 5678:5678
-        # command: python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m example.input_worker
-        command: python -m example.input_worker
+  input_worker:
+    environment:
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - KAFKA_BROKERS=kafka:9092
+    build:
+      target: dev
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      - kafka
+      - redis
+    volumes:
+      - ./:/app/
+    # ports:
+    #     - 3000:3000
+    #     - 5678:5678
+    # command: python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m example.input_worker
+    command: python -m example.input_worker
 
-    middle_worker:
-        environment:
-            - REDIS_HOST=redis
-            - REDIS_PORT=6379
-            - KAFKA_BROKERS=kafka:9092
-        build:
-            target: dev
-            context: .
-            dockerfile: Dockerfile
-        depends_on:
-            - redis
-        volumes:
-            - ./:/app/
-        # ports:
-        #     - 3000:3000
-        #     - 5678:5678
-        # command: python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m example.middle_worker
-        command: python -m example.middle_worker
+  middle_worker:
+    environment:
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - KAFKA_BROKERS=kafka:9092
+    build:
+      target: dev
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      - redis
+    volumes:
+      - ./:/app/
+    # ports:
+    #     - 3000:3000
+    #     - 5678:5678
+    # command: python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m example.middle_worker
+    command: python -m example.middle_worker
 
-    data_consumer:
-        environment:
-            - REDIS_HOST=redis
-            - REDIS_PORT=6379
-        build:
-            target: dev
-            context: .
-            dockerfile: Dockerfile
-        volumes:
-            - ./:/app/
-        depends_on:
-            - kafka
-        # ports:
-        #     - 5678:5678
-        # command: python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m example.external_data_consumer
-        command: python -m example.external_data_consumer
+  zmq_worker:
+    environment:
+      - ZMQ_PORT=5555
+    build:
+      target: dev
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./:/app/
+    command: python -m example.zmq_server
 
-    redis:
-        container_name: redis
-        image: redis:latest
-        ports:
-            - 6379:6379
-        healthcheck:
-            test: ["CMD", "redis-cli", "ping"]
-            interval: 5s
-            timeout: 30s
-            retries: 50
+  data_consumer:
+    environment:
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+    build:
+      target: dev
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./:/app/
+    depends_on:
+      - kafka
+    # ports:
+    #     - 5678:5678
+    # command: python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m example.external_data_consumer
+    command: python -m example.external_data_consumer
 
-    zookeeper:
-        image: confluentinc/cp-zookeeper:5.2.5
-        ports:
-            - "2181:2181"
-        environment:
-            ZOOKEEPER_CLIENT_PORT: 2181
-            ZOOKEEPER_TICK_TIME: 2000
-            KAFKA_JMX_PORT: 39999
+  redis:
+    container_name: redis
+    image: redis:latest
+    ports:
+      - 6379:6379
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 30s
+      retries: 50
 
-    kafka:
-        image: confluentinc/cp-kafka:5.2.5
-        container_name: kafka
-        restart: always
-        depends_on:
-            - zookeeper
-        ports:
-            - "9092:9092"
-            - "29092:29092"
-            - "7071:7071"
-            - "49999:49999"
-        # https://rmoff.net/2018/08/02/kafka-listeners-explained/
-        environment:
-            KAFKA_BROKER_ID: 1
-            KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-            KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
-            KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-            KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-            KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-            KAFKA_JMX_PORT: 49999
+  zookeeper:
+    image: confluentinc/cp-zookeeper:5.2.5
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+      KAFKA_JMX_PORT: 39999
 
-    postgres:
-        restart: always
-        image: postgres:12.3
-        container_name: postgres
-        ports:
-            - 5432:5432
-        environment:
-            POSTGRES_PASSWORD: password
+  kafka:
+    image: confluentinc/cp-kafka:5.2.5
+    container_name: kafka
+    restart: always
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+      - "7071:7071"
+      - "49999:49999"
+    # https://rmoff.net/2018/08/02/kafka-listeners-explained/
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_JMX_PORT: 49999
 
-    int-tests:
-        build:
-            context: .
-            dockerfile: Dockerfile
-            target: dev
-        environment:
-            KAFKA_BROKERS: kafka:9092
-        volumes:
-            - ./:/app/
-        command: pytest tests/integration_tests/test_integration.py
+  postgres:
+    restart: always
+    image: postgres:12.3
+    container_name: postgres
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_PASSWORD: password
+
+  int-tests:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: dev
+    environment:
+      KAFKA_BROKERS: kafka:9092
+    volumes:
+      - ./:/app/
+    command: pytest tests/integration_tests/test_integration.py

--- a/example/zmq_client.py
+++ b/example/zmq_client.py
@@ -1,11 +1,9 @@
 # https://learning-0mq-with-pyzmq.readthedocs.io/en/latest/pyzmq/patterns/client_server.html
-import sys
-
 import msgpack
 import zmq
 
 
-def main():
+def main() -> None:
     port = 5555
     context = zmq.Context()
     print("Connecting to server...")

--- a/example/zmq_client.py
+++ b/example/zmq_client.py
@@ -12,7 +12,7 @@ def main() -> None:
 
     for request in range(1, 10):
         print("Sending request ", request, "...")
-        msg = {"hello": f"cat: {request}"}
+        msg = {"req_id": request, "height": 10, "weight": 200}
         socket.send(msgpack.dumps(msg))
         _message = socket.recv()
         message = msgpack.loads(_message)

--- a/example/zmq_client.py
+++ b/example/zmq_client.py
@@ -1,0 +1,25 @@
+# https://learning-0mq-with-pyzmq.readthedocs.io/en/latest/pyzmq/patterns/client_server.html
+import sys
+
+import msgpack
+import zmq
+
+
+def main():
+    port = 5555
+    context = zmq.Context()
+    print("Connecting to server...")
+    socket = context.socket(zmq.REQ)
+    socket.connect("tcp://localhost:%s" % port)
+
+    for request in range(1, 10):
+        print("Sending request ", request, "...")
+        msg = {"hello": f"cat: {request}"}
+        socket.send(msgpack.dumps(msg))
+        _message = socket.recv()
+        message = msgpack.loads(_message)
+        print("Received reply ", request, "[", message, "]")
+
+
+if __name__ == "__main__":
+    main()

--- a/example/zmq_server.py
+++ b/example/zmq_server.py
@@ -1,0 +1,44 @@
+import logging
+from typing import Dict, List, Tuple
+
+from pydantic import BaseModel
+
+from example.data_models import InputMessage, Queue1Message
+from volley import Engine
+from volley.logging import logger
+
+logging.basicConfig(level=logging.INFO)
+from volley.connectors import ZMQConsumer, ZMQProducer
+from volley.models import PydanticModelHandler
+from volley.serializers import MsgPackSerialization
+
+
+class InputMessage(BaseModel):
+    hello: str
+
+
+cfg = {
+    "request": {
+        "value": "zmq",
+        "consumer": ZMQConsumer,
+        "producer": ZMQProducer,
+        "serializer": MsgPackSerialization,
+        "model_handler": PydanticModelHandler,
+        "data_model": InputMessage,
+        "config": {"port": 5555},
+    },
+}
+
+
+eng = Engine(input_queue="request", output_queues=["request"], queue_config=cfg)
+
+
+@eng.stream_app
+async def main(msg: InputMessage) -> List[Tuple[str, Queue1Message, Dict[str, float]]]:
+    logger.info(msg)
+    msg.hello = "dog" + msg.hello
+    return [("request", msg)]
+
+
+if __name__ == "__main__":
+    main()

--- a/example/zmq_server.py
+++ b/example/zmq_server.py
@@ -12,10 +12,13 @@ from volley.serializers import MsgPackSerialization
 
 logging.basicConfig(level=logging.INFO)
 
+ZMQ_PORT = os.getenv("ZMQ_PORT", 5555)
+
 
 class InputMessage(BaseModel):
     height: float
     weight: float
+    req_id: int = 0
 
 
 class BMI(BaseModel):
@@ -29,7 +32,7 @@ cfg = {
         "serializer": MsgPackSerialization,
         "model_handler": PydanticModelHandler,
         "data_model": InputMessage,
-        "config": {"port": os.environ["ZMQ_PORT"]},
+        "config": {"port": ZMQ_PORT},
     },
     "response": {
         "value": "zmq",
@@ -37,7 +40,7 @@ cfg = {
         "serializer": MsgPackSerialization,
         "model_handler": PydanticModelHandler,
         "data_model": BMI,
-        "config": {"port": os.environ["ZMQ_PORT"]},
+        "config": {"port": ZMQ_PORT},
     },
 }
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -79,6 +79,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "cffi"
+version = "1.15.0"
+description = "Foreign Function Interface for Python calling C code."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pycparser = "*"
+
+[[package]]
 name = "charset-normalizer"
 version = "2.0.12"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -540,7 +551,7 @@ python-versions = ">=3.6"
 name = "py"
 version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -549,6 +560,14 @@ name = "pycodestyle"
 version = "2.7.0"
 description = "Python style guide checker"
 category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pycparser"
+version = "2.21"
+description = "C parser in Python"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -726,6 +745,18 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 pyyaml = "*"
+
+[[package]]
+name = "pyzmq"
+version = "22.3.0"
+description = "Python bindings for 0MQ"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+cffi = {version = "*", markers = "implementation_name == \"pypy\""}
+py = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "rcslice"
@@ -931,10 +962,21 @@ python-versions = ">=3.7"
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
+[[package]]
+name = "zmq"
+version = "0.0.0"
+description = "You are probably looking for pyzmq."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pyzmq = "*"
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.11"
-content-hash = "e6d243bbc03bc88195fa2cd6a97856af88b0a02e80476f4ec0d1147a462b9390"
+content-hash = "d0e954718ba4e4973c087d847eedbbc9dc209dace7927e15cad0a67f295cc9a8"
 
 [metadata.files]
 astroid = [
@@ -960,6 +1002,58 @@ black = [
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
     {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
+]
+cffi = [
+    {file = "cffi-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c2502a1a03b6312837279c8c1bd3ebedf6c12c4228ddbad40912d671ccc8a962"},
+    {file = "cffi-1.15.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:23cfe892bd5dd8941608f93348c0737e369e51c100d03718f108bf1add7bd6d0"},
+    {file = "cffi-1.15.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:41d45de54cd277a7878919867c0f08b0cf817605e4eb94093e7516505d3c8d14"},
+    {file = "cffi-1.15.0-cp27-cp27m-win32.whl", hash = "sha256:4a306fa632e8f0928956a41fa8e1d6243c71e7eb59ffbd165fc0b41e316b2474"},
+    {file = "cffi-1.15.0-cp27-cp27m-win_amd64.whl", hash = "sha256:e7022a66d9b55e93e1a845d8c9eba2a1bebd4966cd8bfc25d9cd07d515b33fa6"},
+    {file = "cffi-1.15.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:14cd121ea63ecdae71efa69c15c5543a4b5fbcd0bbe2aad864baca0063cecf27"},
+    {file = "cffi-1.15.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:d4d692a89c5cf08a8557fdeb329b82e7bf609aadfaed6c0d79f5a449a3c7c023"},
+    {file = "cffi-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0104fb5ae2391d46a4cb082abdd5c69ea4eab79d8d44eaaf79f1b1fd806ee4c2"},
+    {file = "cffi-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:91ec59c33514b7c7559a6acda53bbfe1b283949c34fe7440bcf917f96ac0723e"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f5c7150ad32ba43a07c4479f40241756145a1f03b43480e058cfd862bf5041c7"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:00c878c90cb53ccfaae6b8bc18ad05d2036553e6d9d1d9dbcf323bbe83854ca3"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abb9a20a72ac4e0fdb50dae135ba5e77880518e742077ced47eb1499e29a443c"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a5263e363c27b653a90078143adb3d076c1a748ec9ecc78ea2fb916f9b861962"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f54a64f8b0c8ff0b64d18aa76675262e1700f3995182267998c31ae974fbc382"},
+    {file = "cffi-1.15.0-cp310-cp310-win32.whl", hash = "sha256:c21c9e3896c23007803a875460fb786118f0cdd4434359577ea25eb556e34c55"},
+    {file = "cffi-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:5e069f72d497312b24fcc02073d70cb989045d1c91cbd53979366077959933e0"},
+    {file = "cffi-1.15.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:64d4ec9f448dfe041705426000cc13e34e6e5bb13736e9fd62e34a0b0c41566e"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2756c88cbb94231c7a147402476be2c4df2f6078099a6f4a480d239a8817ae39"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b96a311ac60a3f6be21d2572e46ce67f09abcf4d09344c49274eb9e0bf345fc"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75e4024375654472cc27e91cbe9eaa08567f7fbdf822638be2814ce059f58032"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:59888172256cac5629e60e72e86598027aca6bf01fa2465bdb676d37636573e8"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:27c219baf94952ae9d50ec19651a687b826792055353d07648a5695413e0c605"},
+    {file = "cffi-1.15.0-cp36-cp36m-win32.whl", hash = "sha256:4958391dbd6249d7ad855b9ca88fae690783a6be9e86df65865058ed81fc860e"},
+    {file = "cffi-1.15.0-cp36-cp36m-win_amd64.whl", hash = "sha256:f6f824dc3bce0edab5f427efcfb1d63ee75b6fcb7282900ccaf925be84efb0fc"},
+    {file = "cffi-1.15.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:06c48159c1abed75c2e721b1715c379fa3200c7784271b3c46df01383b593636"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c2051981a968d7de9dd2d7b87bcb9c939c74a34626a6e2f8181455dd49ed69e4"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:fd8a250edc26254fe5b33be00402e6d287f562b6a5b2152dec302fa15bb3e997"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91d77d2a782be4274da750752bb1650a97bfd8f291022b379bb8e01c66b4e96b"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:45db3a33139e9c8f7c09234b5784a5e33d31fd6907800b316decad50af323ff2"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:263cc3d821c4ab2213cbe8cd8b355a7f72a8324577dc865ef98487c1aeee2bc7"},
+    {file = "cffi-1.15.0-cp37-cp37m-win32.whl", hash = "sha256:17771976e82e9f94976180f76468546834d22a7cc404b17c22df2a2c81db0c66"},
+    {file = "cffi-1.15.0-cp37-cp37m-win_amd64.whl", hash = "sha256:3415c89f9204ee60cd09b235810be700e993e343a408693e80ce7f6a40108029"},
+    {file = "cffi-1.15.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4238e6dab5d6a8ba812de994bbb0a79bddbdf80994e4ce802b6f6f3142fcc880"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0808014eb713677ec1292301ea4c81ad277b6cdf2fdd90fd540af98c0b101d20"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:57e9ac9ccc3101fac9d6014fba037473e4358ef4e89f8e181f8951a2c0162024"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b6c2ea03845c9f501ed1313e78de148cd3f6cad741a75d43a29b43da27f2e1e"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:10dffb601ccfb65262a27233ac273d552ddc4d8ae1bf93b21c94b8511bffe728"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:786902fb9ba7433aae840e0ed609f45c7bcd4e225ebb9c753aa39725bb3e6ad6"},
+    {file = "cffi-1.15.0-cp38-cp38-win32.whl", hash = "sha256:da5db4e883f1ce37f55c667e5c0de439df76ac4cb55964655906306918e7363c"},
+    {file = "cffi-1.15.0-cp38-cp38-win_amd64.whl", hash = "sha256:181dee03b1170ff1969489acf1c26533710231c58f95534e3edac87fff06c443"},
+    {file = "cffi-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:45e8636704eacc432a206ac7345a5d3d2c62d95a507ec70d62f23cd91770482a"},
+    {file = "cffi-1.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:31fb708d9d7c3f49a60f04cf5b119aeefe5644daba1cd2a0fe389b674fd1de37"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6dc2737a3674b3e344847c8686cf29e500584ccad76204efea14f451d4cc669a"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:74fdfdbfdc48d3f47148976f49fab3251e550a8720bebc99bf1483f5bfb5db3e"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffaa5c925128e29efbde7301d8ecaf35c8c60ffbcd6a1ffd3a552177c8e5e796"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f7d084648d77af029acb79a0ff49a0ad7e9d09057a9bf46596dac9514dc07df"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef1f279350da2c586a69d32fc8733092fd32cc8ac95139a00377841f59a3f8d8"},
+    {file = "cffi-1.15.0-cp39-cp39-win32.whl", hash = "sha256:2a23af14f408d53d5e6cd4e3d9a24ff9e05906ad574822a10563efcef137979a"},
+    {file = "cffi-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:3773c4d81e6e818df2efbc7dd77325ca0dcb688116050fb2b3011218eda36139"},
+    {file = "cffi-1.15.0.tar.gz", hash = "sha256:920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954"},
 ]
 charset-normalizer = [
     {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
@@ -1504,6 +1598,10 @@ pycodestyle = [
     {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
     {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
 ]
+pycparser = [
+    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
+    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
 pydantic = [
     {file = "pydantic-1.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cb23bcc093697cdea2708baae4f9ba0e972960a835af22560f6ae4e7e47d33f5"},
     {file = "pydantic-1.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1d5278bd9f0eee04a44c712982343103bba63507480bfd2fc2790fa70cd64cf4"},
@@ -1619,6 +1717,55 @@ pyyaml = [
 pyyaml-env-tag = [
     {file = "pyyaml_env_tag-0.1-py3-none-any.whl", hash = "sha256:af31106dec8a4d68c60207c1886031cbf839b68aa7abccdb19868200532c2069"},
     {file = "pyyaml_env_tag-0.1.tar.gz", hash = "sha256:70092675bda14fdec33b31ba77e7543de9ddc88f2e5b99160396572d11525bdb"},
+]
+pyzmq = [
+    {file = "pyzmq-22.3.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:6b217b8f9dfb6628f74b94bdaf9f7408708cb02167d644edca33f38746ca12dd"},
+    {file = "pyzmq-22.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2841997a0d85b998cbafecb4183caf51fd19c4357075dfd33eb7efea57e4c149"},
+    {file = "pyzmq-22.3.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f89468059ebc519a7acde1ee50b779019535db8dcf9b8c162ef669257fef7a93"},
+    {file = "pyzmq-22.3.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ea12133df25e3a6918718fbb9a510c6ee5d3fdd5a346320421aac3882f4feeea"},
+    {file = "pyzmq-22.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76c532fd68b93998aab92356be280deec5de8f8fe59cd28763d2cc8a58747b7f"},
+    {file = "pyzmq-22.3.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:f907c7359ce8bf7f7e63c82f75ad0223384105f5126f313400b7e8004d9b33c3"},
+    {file = "pyzmq-22.3.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:902319cfe23366595d3fa769b5b751e6ee6750a0a64c5d9f757d624b2ac3519e"},
+    {file = "pyzmq-22.3.0-cp310-cp310-win32.whl", hash = "sha256:67db33bea0a29d03e6eeec55a8190e033318cee3cbc732ba8fd939617cbf762d"},
+    {file = "pyzmq-22.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:7661fc1d5cb73481cf710a1418a4e1e301ed7d5d924f91c67ba84b2a1b89defd"},
+    {file = "pyzmq-22.3.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79244b9e97948eaf38695f4b8e6fc63b14b78cc37f403c6642ba555517ac1268"},
+    {file = "pyzmq-22.3.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab888624ed68930442a3f3b0b921ad7439c51ba122dbc8c386e6487a658e4a4e"},
+    {file = "pyzmq-22.3.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:18cd854b423fce44951c3a4d3e686bac8f1243d954f579e120a1714096637cc0"},
+    {file = "pyzmq-22.3.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:de8df0684398bd74ad160afdc2a118ca28384ac6f5e234eb0508858d8d2d9364"},
+    {file = "pyzmq-22.3.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:62bcade20813796c426409a3e7423862d50ff0639f5a2a95be4b85b09a618666"},
+    {file = "pyzmq-22.3.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:ea5a79e808baef98c48c884effce05c31a0698c1057de8fc1c688891043c1ce1"},
+    {file = "pyzmq-22.3.0-cp36-cp36m-win32.whl", hash = "sha256:3c1895c95be92600233e476fe283f042e71cf8f0b938aabf21b7aafa62a8dac9"},
+    {file = "pyzmq-22.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:851977788b9caa8ed011f5f643d3ee8653af02c5fc723fa350db5125abf2be7b"},
+    {file = "pyzmq-22.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b4ebed0977f92320f6686c96e9e8dd29eed199eb8d066936bac991afc37cbb70"},
+    {file = "pyzmq-22.3.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42abddebe2c6a35180ca549fadc7228d23c1e1f76167c5ebc8a936b5804ea2df"},
+    {file = "pyzmq-22.3.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1e41b32d6f7f9c26bc731a8b529ff592f31fc8b6ef2be9fa74abd05c8a342d7"},
+    {file = "pyzmq-22.3.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:be4e0f229cf3a71f9ecd633566bd6f80d9fa6afaaff5489492be63fe459ef98c"},
+    {file = "pyzmq-22.3.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:08c4e315a76ef26eb833511ebf3fa87d182152adf43dedee8d79f998a2162a0b"},
+    {file = "pyzmq-22.3.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:badb868fff14cfd0e200eaa845887b1011146a7d26d579aaa7f966c203736b92"},
+    {file = "pyzmq-22.3.0-cp37-cp37m-win32.whl", hash = "sha256:7c58f598d9fcc52772b89a92d72bf8829c12d09746a6d2c724c5b30076c1f11d"},
+    {file = "pyzmq-22.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2b97502c16a5ec611cd52410bdfaab264997c627a46b0f98d3f666227fd1ea2d"},
+    {file = "pyzmq-22.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d728b08448e5ac3e4d886b165385a262883c34b84a7fe1166277fe675e1c197a"},
+    {file = "pyzmq-22.3.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:480b9931bfb08bf8b094edd4836271d4d6b44150da051547d8c7113bf947a8b0"},
+    {file = "pyzmq-22.3.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7dc09198e4073e6015d9a8ea093fc348d4e59de49382476940c3dd9ae156fba8"},
+    {file = "pyzmq-22.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ca6cd58f62a2751728016d40082008d3b3412a7f28ddfb4a2f0d3c130f69e74"},
+    {file = "pyzmq-22.3.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:468bd59a588e276961a918a3060948ae68f6ff5a7fa10bb2f9160c18fe341067"},
+    {file = "pyzmq-22.3.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c88fa7410e9fc471e0858638f403739ee869924dd8e4ae26748496466e27ac59"},
+    {file = "pyzmq-22.3.0-cp38-cp38-win32.whl", hash = "sha256:c0f84360dcca3481e8674393bdf931f9f10470988f87311b19d23cda869bb6b7"},
+    {file = "pyzmq-22.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:f762442bab706fd874064ca218b33a1d8e40d4938e96c24dafd9b12e28017f45"},
+    {file = "pyzmq-22.3.0-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:954e73c9cd4d6ae319f1c936ad159072b6d356a92dcbbabfd6e6204b9a79d356"},
+    {file = "pyzmq-22.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f43b4a2e6218371dd4f41e547bd919ceeb6ebf4abf31a7a0669cd11cd91ea973"},
+    {file = "pyzmq-22.3.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:acebba1a23fb9d72b42471c3771b6f2f18dcd46df77482612054bd45c07dfa36"},
+    {file = "pyzmq-22.3.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cf98fd7a6c8aaa08dbc699ffae33fd71175696d78028281bc7b832b26f00ca57"},
+    {file = "pyzmq-22.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d072f7dfbdb184f0786d63bda26e8a0882041b1e393fbe98940395f7fab4c5e2"},
+    {file = "pyzmq-22.3.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:53f4fd13976789ffafedd4d46f954c7bb01146121812b72b4ddca286034df966"},
+    {file = "pyzmq-22.3.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d1b5d457acbadcf8b27561deeaa386b0217f47626b29672fa7bd31deb6e91e1b"},
+    {file = "pyzmq-22.3.0-cp39-cp39-win32.whl", hash = "sha256:e6a02cf7271ee94674a44f4e62aa061d2d049001c844657740e156596298b70b"},
+    {file = "pyzmq-22.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:d3dcb5548ead4f1123851a5ced467791f6986d68c656bc63bfff1bf9e36671e2"},
+    {file = "pyzmq-22.3.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3a4c9886d61d386b2b493377d980f502186cd71d501fffdba52bd2a0880cef4f"},
+    {file = "pyzmq-22.3.0-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:80e043a89c6cadefd3a0712f8a1322038e819ebe9dbac7eca3bce1721bcb63bf"},
+    {file = "pyzmq-22.3.0-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1621e7a2af72cced1f6ec8ca8ca91d0f76ac236ab2e8828ac8fe909512d566cb"},
+    {file = "pyzmq-22.3.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:d6157793719de168b199194f6b6173f0ccd3bf3499e6870fac17086072e39115"},
+    {file = "pyzmq-22.3.0.tar.gz", hash = "sha256:8eddc033e716f8c91c6a2112f0a8ebc5e00532b4a6ae1eb0ccc48e027f9c671c"},
 ]
 rcslice = [
     {file = "rcslice-1.1.0-py3-none-any.whl", hash = "sha256:1b12fc0c0ca452e8a9fd2b56ac008162f19e250906a4290a7e7a98be3200c2a6"},
@@ -1795,4 +1942,8 @@ wrapt = [
 zipp = [
     {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},
     {file = "zipp-3.7.0.tar.gz", hash = "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d"},
+]
+zmq = [
+    {file = "zmq-0.0.0.tar.gz", hash = "sha256:6b1a1de53338646e8c8405803cffb659e8eb7bb02fff4c9be62a7acfac8370c9"},
+    {file = "zmq-0.0.0.zip", hash = "sha256:21cfc6be254c9bc25e4dabb8a3b2006a4227966b7b39a637426084c8dc6901f7"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -962,21 +962,10 @@ python-versions = ">=3.7"
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
-[[package]]
-name = "zmq"
-version = "0.0.0"
-description = "You are probably looking for pyzmq."
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-pyzmq = "*"
-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.11"
-content-hash = "d0e954718ba4e4973c087d847eedbbc9dc209dace7927e15cad0a67f295cc9a8"
+content-hash = "8a3d11b26e715d537bd42ea4415678375cb76930a84cf0ca095584b4c746dad6"
 
 [metadata.files]
 astroid = [
@@ -1942,8 +1931,4 @@ wrapt = [
 zipp = [
     {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},
     {file = "zipp-3.7.0.tar.gz", hash = "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d"},
-]
-zmq = [
-    {file = "zmq-0.0.0.tar.gz", hash = "sha256:6b1a1de53338646e8c8405803cffb659e8eb7bb02fff4c9be62a7acfac8370c9"},
-    {file = "zmq-0.0.0.zip", hash = "sha256:21cfc6be254c9bc25e4dabb8a3b2006a4227966b7b39a637426084c8dc6901f7"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ orjson = "^3.6.4"
 msgpack = "^1.0.3"
 confluent-kafka = "^1.7.0"
 tenacity = "^8.0.1"
+zmq = "^0.0.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.9.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ orjson = "^3.6.4"
 msgpack = "^1.0.3"
 confluent-kafka = "^1.7.0"
 tenacity = "^8.0.1"
-zmq = "^0.0.0"
+pyzmq = "^22.3.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.9.2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ follow_imports=normal
 ignore_missing_imports=True
 
 # be strict
-disallow_untyped_calls=True
+disallow_untyped_calls=False
 warn_return_any=True
 strict_optional=True
 warn_no_return=True

--- a/tests/test_connectors/test_zmq.py
+++ b/tests/test_connectors/test_zmq.py
@@ -19,7 +19,7 @@ def test_zmqconsumer(mocked_zsmq: MagicMock) -> None:
 
 
 @patch("volley.connectors.zmq._socket")
-def test_zmqproducer(mocked_zsmq: MagicMock) -> None:
+def test_zmqproducer(mocked_zsmq: MagicMock) -> None:  # pylint: disable=W0613
     msg = b"test-message"
     producer = ZMQProducer(host="redis", queue_name="test", config={"port": 5555})
     producer.produce(queue_name="test", message=msg)

--- a/tests/test_connectors/test_zmq.py
+++ b/tests/test_connectors/test_zmq.py
@@ -1,0 +1,26 @@
+from unittest.mock import MagicMock, patch
+
+from volley.connectors import ZMQConsumer, ZMQProducer
+from volley.data_models import QueueMessage
+
+
+@patch("volley.connectors.zmq._socket")
+def test_zmqconsumer(mocked_zsmq: MagicMock) -> None:
+    msg = "test-message"
+    mocked_zsmq.recv.return_value = msg
+    consumer = ZMQConsumer(host="redis", queue_name="test", config={"port": 5555})
+    consumed_msg = consumer.consume()
+    assert isinstance(consumed_msg, QueueMessage)
+    assert msg == consumed_msg.message
+
+    # these dont do anything in the send-receive use-case
+    consumer.on_fail("")
+    consumer.on_success("")
+
+
+@patch("volley.connectors.zmq._socket")
+def test_zmqproducer(mocked_zsmq: MagicMock) -> None:
+    msg = b"test-message"
+    producer = ZMQProducer(host="redis", queue_name="test", config={"port": 5555})
+    producer.produce(queue_name="test", message=msg)
+    producer.shutdown()

--- a/volley/connectors/__init__.py
+++ b/volley/connectors/__init__.py
@@ -1,9 +1,12 @@
 from volley.connectors.confluent import ConfluentKafkaConsumer, ConfluentKafkaProducer
 from volley.connectors.rsmq import RSMQConsumer, RSMQProducer
+from volley.connectors.zmq import ZMQConsumer, ZMQProducer
 
 __all__ = [
     "ConfluentKafkaConsumer",
     "ConfluentKafkaProducer",
     "RSMQConsumer",
     "RSMQProducer",
+    "ZMQConsumer",
+    "ZMQProducer",
 ]

--- a/volley/connectors/zmq.py
+++ b/volley/connectors/zmq.py
@@ -44,7 +44,7 @@ class ZMQConsumer(BaseConsumer):
     def consume(self) -> Optional[QueueMessage]:
         global _socket
         _start = time.time()
-        msg = _socket.recv()
+        msg = _socket.recv()  # type: ignore
         _duration = time.time() - _start
         PROCESS_TIME.labels("read").observe(_duration)
         if msg:
@@ -61,7 +61,7 @@ class ZMQConsumer(BaseConsumer):
     def shutdown(self) -> None:
         global _socket
         global _socket
-        _socket.close()
+        _socket.close()  # type: ignore
         context.term()
 
 
@@ -87,7 +87,7 @@ class ZMQProducer(BaseProducer):
     ) -> bool:
         global _socket
         _start = time.time()
-        _socket.send(message)
+        _socket.send(message)  # type: ignore
         _duration = time.time() - _start
         PROCESS_TIME.labels("write").observe(_duration)
         return True
@@ -95,5 +95,5 @@ class ZMQProducer(BaseProducer):
     def shutdown(self) -> None:
         global _socket
         global _socket
-        _socket.close()
+        _socket.close()  # type: ignore
         context.term()

--- a/volley/connectors/zmq.py
+++ b/volley/connectors/zmq.py
@@ -1,0 +1,99 @@
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Optional, Union
+
+import zmq
+from prometheus_client import Summary
+
+from volley.connectors.base import BaseConsumer, BaseProducer
+from volley.data_models import QueueMessage
+from volley.logging import logger
+
+PROCESS_TIME = Summary("zmq_process_time_seconds", "Time spent interacting with zmq", ["operation"])
+
+context = zmq.Context()
+_socket = None
+
+
+def init_zmq(port: int) -> None:
+    global context
+    global _socket
+    if _socket is None:
+        _socket = context.socket(zmq.REP)
+        _socket.bind("tcp://*:%s" % port)
+    else:
+        logger.info("Socket already initialized")
+
+
+@dataclass
+class ZMQConsumer(BaseConsumer):
+    def __post_init__(self) -> None:
+        if "host" in self.config:
+            # pass the value directly to the constructor
+            pass
+        elif host := os.getenv("ZMQ_HOST"):
+            self.config["host"] = host
+        if "port" in self.config:
+            # pass the value directly to the constructor
+            pass
+        elif host := os.getenv("ZMQ_PORT"):
+            self.config["port"] = host
+        init_zmq(port=self.config["port"])
+
+    def consume(self) -> Optional[QueueMessage]:
+        global _socket
+        _start = time.time()
+        msg = _socket.recv()
+        _duration = time.time() - _start
+        PROCESS_TIME.labels("read").observe(_duration)
+        if msg:
+            return QueueMessage(message_context=None, message=msg)
+        else:
+            return None
+
+    def on_success(self, message_context: str) -> None:
+        pass
+
+    def on_fail(self, message_context: str) -> None:
+        pass
+
+    def shutdown(self) -> None:
+        global _socket
+        global _socket
+        _socket.close()
+        context.term()
+
+
+@dataclass
+class ZMQProducer(BaseProducer):
+    def __post_init__(self) -> None:
+        # delivery reports are synchronous
+        self.callback_delivery = False
+        if "host" in self.config:
+            # pass the value directly to the constructor
+            pass
+        elif host := os.getenv("ZMQ_HOST"):
+            self.config["host"] = host
+        if "port" in self.config:
+            # pass the value directly to the constructor
+            pass
+        elif host := os.getenv("ZMQ_PORT"):
+            self.config["port"] = host
+        init_zmq(port=self.config["port"])
+
+    def produce(
+        self, queue_name: str, message: bytes, message_context: Optional[Any] = None, **kwargs: Union[str, int]
+    ) -> bool:
+        global _socket
+        _start = time.time()
+        _socket.send(message)
+        _duration = time.time() - _start
+        PROCESS_TIME.labels("write").observe(_duration)
+        return True
+
+    def shutdown(self) -> None:
+        global _socket
+        global _socket
+        _socket.close()
+        context.term()

--- a/volley/connectors/zmq.py
+++ b/volley/connectors/zmq.py
@@ -47,10 +47,7 @@ class ZMQConsumer(BaseConsumer):
         msg = _socket.recv()  # type: ignore
         _duration = time.time() - _start
         PROCESS_TIME.labels("read").observe(_duration)
-        if msg:
-            return QueueMessage(message_context=None, message=msg)
-        else:
-            return None
+        return QueueMessage(message_context=None, message=msg)
 
     def on_success(self, message_context: str) -> None:
         pass


### PR DESCRIPTION
ZeroMQ connector fits in fairly well with the Consumer/Producer abstractions, but only supports the [client/server](https://learning-0mq-with-pyzmq.readthedocs.io/en/latest/pyzmq/patterns/client_server.html) messaging pattern in this implementation and is quite a bit different from the rsmq and confluent connectors.

- client (any language) sends request on `tcp://*:<port>` using zeromq protocol to server (python/volley app on `ZmqConnector`). 
- Server listens on that port, parses message using whichever serializer and model handler we specify (can be None if we dont want any validation), processes message
- server responds on same socket/context back to client

`python -m example.zmq_client` (this could be substituted with any language interfacing with zmq)
`python -m example.zmq_server`