### PR TITLE
connectors on their own loggers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "py_volley"
-version = "0.17.0"
+version = "0.17.1"
 description = "Pluggable message queueing for Python"
 authors = ["ask-machine-learning <shipt@shipt.com>"]
 

--- a/volley/__init__.py
+++ b/volley/__init__.py
@@ -1,5 +1,5 @@
 from volley.engine import Engine
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"
 
 __all__ = ["Engine"]

--- a/volley/connectors/confluent.py
+++ b/volley/connectors/confluent.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from dataclasses import dataclass
 from threading import Thread
@@ -8,7 +9,8 @@ from prometheus_client import Counter
 
 from volley.connectors.base import BaseConsumer, BaseProducer
 from volley.data_models import QueueMessage
-from volley.logging import logger
+
+logger = logging.getLogger(__name__)
 
 DELIVERY_STATUS = Counter("delivery_report_status", "Kafka delivered message", ["status"])
 

--- a/volley/connectors/rsmq.py
+++ b/volley/connectors/rsmq.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import time
 from dataclasses import dataclass
@@ -9,7 +10,8 @@ from tenacity import retry, stop_after_attempt, wait_exponential, wait_fixed
 
 from volley.connectors.base import BaseConsumer, BaseProducer
 from volley.data_models import QueueMessage
-from volley.logging import logger
+
+logger = logging.getLogger(__name__)
 
 PROCESS_TIME = Summary("redis_process_time_seconds", "Time spent interacting with rsmq", ["operation"])
 

--- a/volley/connectors/zmq.py
+++ b/volley/connectors/zmq.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import time
 from dataclasses import dataclass
@@ -8,7 +9,8 @@ from prometheus_client import Summary
 
 from volley.connectors.base import BaseConsumer, BaseProducer
 from volley.data_models import QueueMessage
-from volley.logging import logger
+
+logger = logging.getLogger(__name__)
 
 PROCESS_TIME = Summary("zmq_process_time_seconds", "Time spent interacting with zmq", ["operation"])
 


### PR DESCRIPTION
Each connector is now on its own logger. This will let users add/remove handlers from those loggers, instead of having the blanket "volley" logger.