### PR TITLE
release 0.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "py_volley"
-version = "0.19.0"
+version = "0.20.0"
 description = "Pluggable message queueing for Python"
 authors = ["ask-machine-learning <shipt@shipt.com>"]
 readme = "README.md"

--- a/volley/__init__.py
+++ b/volley/__init__.py
@@ -1,5 +1,5 @@
 from volley.engine import Engine
 
-__version__ = "0.19.0"
+__version__ = "0.20.0"
 
 __all__ = ["Engine"]


### PR DESCRIPTION
- QueueMessage.message_context is (optionally) available to all consumer
- kafka consumers can be configured to fail/shutdown when producing downstream fails