### PR TITLE
patch ZMQ init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test.unit: setup
 			--cov-report term
 
 run.components:
-	docker-compose up --build -d input_worker middle_worker zmq_worker
+	docker-compose up --build -d input_worker middle_worker zmq-worker
 
 run.example: run.datastores run.components run.externals
 	docker compose up --build -d data_producer input_worker middle_worker data_consumer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     # command: python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m example.middle_worker
     command: python -m example.middle_worker
 
-  zmq_worker:
+  zmq-worker:
     environment:
       - ZMQ_PORT=5555
     build:

--- a/example/middle_worker.py
+++ b/example/middle_worker.py
@@ -63,7 +63,7 @@ port = 5555
 context = zmq.Context()
 print("Connecting to server...")
 socket = context.socket(zmq.REQ)
-socket.connect("tcp://zmq_worker:%s" % port)
+socket.connect("tcp://zmq-worker:%s" % port)
 
 
 class BMI(BaseModel):

--- a/example/zmq_server.py
+++ b/example/zmq_server.py
@@ -45,7 +45,7 @@ cfg = {
 }
 
 
-eng = Engine(input_queue="request", output_queues=["response"], queue_config=cfg)
+eng = Engine(app_name="zmq_worker", input_queue="request", output_queues=["response"], queue_config=cfg)
 
 
 def calc_bmi(height: float, weight: float) -> BMI:

--- a/tests/integration_tests/test_integration.py
+++ b/tests/integration_tests/test_integration.py
@@ -77,12 +77,12 @@ def test_end_to_end(int_test_producer: Producer, int_test_consumer: Consumer, en
     for m in consumed_messages:
         # assert all consumed IDs were from the list we produced
         _id = m["request_id"]
-        assert _id in request_ids
+        assert _id in request_ids, "consumed unexpected data"
         conusumed_ids.append(_id)
 
     for _id in request_ids:
         # assert all ids we produced were in the list we consumed
-        assert _id in conusumed_ids
+        assert _id in conusumed_ids, "expected data was not consumed"
 
     assert len(request_ids) == len(conusumed_ids)
 

--- a/volley/connectors/zmq.py
+++ b/volley/connectors/zmq.py
@@ -23,7 +23,7 @@ def init_zmq(port: int) -> None:
     global _socket
     if _socket is None:
         _socket = context.socket(zmq.REP)
-        _socket.bind("tcp://*:%s" % port)
+        _socket.bind("tcp://0.0.0.0:%s" % port)
     else:
         logger.info("Socket already initialized")
 
@@ -52,9 +52,11 @@ class ZMQConsumer(BaseConsumer):
         return QueueMessage(message_context=None, message=msg)
 
     def on_success(self, message_context: str) -> None:
+        """No action. Synchronous request/response implementation"""
         pass
 
     def on_fail(self, message_context: str) -> None:
+        """No action. Synchronous request/response implementation"""
         pass
 
     def shutdown(self) -> None:


### PR DESCRIPTION
ZeroMQ needs a properly named DNS. Underscores are [not allowed](https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/naming-conventions-for-computer-domain-site-ou).